### PR TITLE
Fix key destructuring in defn forms

### DIFF
--- a/src/ccw/debug/serverrepl.clj
+++ b/src/ccw/debug/serverrepl.clj
@@ -444,8 +444,8 @@
   "Return a sequence of matching completions given a prefix string 
    and an optional current namespace."
   ([prefix] (completions* prefix *ns*))
-  ([prefix ns & {:keys #{filter} 
-                 :or    {filter ccw.debug.serverrepl/starts-with-filter}}]
+  ([prefix ns & {:keys [filter]
+                 :or   {filter ccw.debug.serverrepl/starts-with-filter}}]
      (for [[kind completions] (potential-completions prefix ns)
            [match-symbol match-object :as completion] completions
            :let [f (filter-completion (name match-symbol) prefix filter)]
@@ -460,10 +460,10 @@
    and an optional current namespace."
   ([prefix] (completions prefix *ns*))
   ([prefix ns limit
-    & {:keys #{filter comparator renderer} 
-       :or    {filter ccw.debug.serverrepl/starts-with-filter
-               comparator compare
-               renderer :completion}}]
+    & {:keys [filter comparator renderer]
+       :or   {filter ccw.debug.serverrepl/starts-with-filter
+              comparator compare
+              renderer :completion}}]
     (map renderer
          (take limit
                (sort-by


### PR DESCRIPTION
```
As of Clojure 1.9, the clojure.spec library has been added. As spec has
been implemented for many core macros, there are some formerly-passing
(but invalid) forms which now throw errors. Key destructuring forms must
be in a vector, but sets were previously allowable. This commit ensures
vectors are used for 1.9 compatability.
```
